### PR TITLE
Restrict legacy apps to insert files to other private app dirs

### DIFF
--- a/src/com/android/providers/media/LocalCallingIdentity.java
+++ b/src/com/android/providers/media/LocalCallingIdentity.java
@@ -21,8 +21,11 @@ import static android.app.AppOpsManager.MODE_ALLOWED;
 import static android.app.AppOpsManager.permissionToOp;
 import static android.content.pm.PackageManager.PERMISSION_DENIED;
 
+import static com.android.providers.media.util.PermissionUtils.checkAppOpRequestInstallPackagesForSharedUid;
 import static com.android.providers.media.util.PermissionUtils.checkIsLegacyStorageGranted;
+import static com.android.providers.media.util.PermissionUtils.checkPermissionAccessMtp;
 import static com.android.providers.media.util.PermissionUtils.checkPermissionDelegator;
+import static com.android.providers.media.util.PermissionUtils.checkPermissionInstallPackages;
 import static com.android.providers.media.util.PermissionUtils.checkPermissionManager;
 import static com.android.providers.media.util.PermissionUtils.checkPermissionReadAudio;
 import static com.android.providers.media.util.PermissionUtils.checkPermissionReadImages;
@@ -216,6 +219,18 @@ public class LocalCallingIdentity {
 
     public static final int PERMISSION_IS_SYSTEM_GALLERY = 1 <<22;
 
+    /**
+     * Explicitly checks **only** for INSTALL_PACKAGES runtime permission.
+     */
+    public static final int PERMISSION_INSTALL_PACKAGES = 1 << 23;
+    public static final int PERMISSION_WRITE_EXTERNAL_STORAGE = 1 << 24;
+
+    /**
+     * Checks if REQUEST_INSTALL_PACKAGES app-op is allowed for any package sharing this UID.
+     */
+    public static final int APPOP_REQUEST_INSTALL_PACKAGES_FOR_SHARED_UID = 1 << 25;
+    public static final int PERMISSION_ACCESS_MTP = 1 << 26;
+
     private int hasPermission;
     private int hasPermissionResolved;
 
@@ -256,6 +271,10 @@ public class LocalCallingIdentity {
             case PERMISSION_IS_LEGACY_WRITE:
                 return isLegacyWriteInternal();
 
+            case PERMISSION_WRITE_EXTERNAL_STORAGE:
+                return checkPermissionWriteStorage(
+                        context, pid, uid, getPackageName(), attributionTag);
+
             case PERMISSION_READ_AUDIO:
                 return checkPermissionReadAudio(
                         context, pid, uid, getPackageName(), attributionTag);
@@ -277,6 +296,15 @@ public class LocalCallingIdentity {
             case PERMISSION_IS_SYSTEM_GALLERY:
                 return checkWriteImagesOrVideoAppOps(
                         context, uid, getPackageName(), attributionTag);
+            case PERMISSION_INSTALL_PACKAGES:
+                return checkPermissionInstallPackages(
+                        context, pid, uid, getPackageName(), attributionTag);
+            case APPOP_REQUEST_INSTALL_PACKAGES_FOR_SHARED_UID:
+                return checkAppOpRequestInstallPackagesForSharedUid(
+                        context, uid, getSharedPackageNames(), attributionTag);
+            case PERMISSION_ACCESS_MTP:
+                return checkPermissionAccessMtp(
+                        context, pid, uid, getPackageName(), attributionTag);
             default:
                 return false;
         }

--- a/src/com/android/providers/media/MediaProvider.java
+++ b/src/com/android/providers/media/MediaProvider.java
@@ -36,6 +36,9 @@ import static android.provider.MediaStore.getVolumeName;
 
 import static com.android.providers.media.DatabaseHelper.EXTERNAL_DATABASE_NAME;
 import static com.android.providers.media.DatabaseHelper.INTERNAL_DATABASE_NAME;
+import static com.android.providers.media.LocalCallingIdentity.APPOP_REQUEST_INSTALL_PACKAGES_FOR_SHARED_UID;
+import static com.android.providers.media.LocalCallingIdentity.PERMISSION_ACCESS_MTP;
+import static com.android.providers.media.LocalCallingIdentity.PERMISSION_INSTALL_PACKAGES;
 import static com.android.providers.media.LocalCallingIdentity.PERMISSION_IS_DELEGATOR;
 import static com.android.providers.media.LocalCallingIdentity.PERMISSION_IS_LEGACY_GRANTED;
 import static com.android.providers.media.LocalCallingIdentity.PERMISSION_IS_LEGACY_READ;
@@ -49,6 +52,7 @@ import static com.android.providers.media.LocalCallingIdentity.PERMISSION_READ_A
 import static com.android.providers.media.LocalCallingIdentity.PERMISSION_READ_IMAGES;
 import static com.android.providers.media.LocalCallingIdentity.PERMISSION_READ_VIDEO;
 import static com.android.providers.media.LocalCallingIdentity.PERMISSION_WRITE_AUDIO;
+import static com.android.providers.media.LocalCallingIdentity.PERMISSION_WRITE_EXTERNAL_STORAGE;
 import static com.android.providers.media.LocalCallingIdentity.PERMISSION_WRITE_IMAGES;
 import static com.android.providers.media.LocalCallingIdentity.PERMISSION_WRITE_VIDEO;
 import static com.android.providers.media.scan.MediaScanner.REASON_DEMAND;
@@ -58,14 +62,17 @@ import static com.android.providers.media.util.FileUtils.DEFAULT_FOLDER_NAMES;
 import static com.android.providers.media.util.FileUtils.PATTERN_PENDING_FILEPATH_FOR_SQL;
 import static com.android.providers.media.util.FileUtils.extractDisplayName;
 import static com.android.providers.media.util.FileUtils.extractFileName;
+import static com.android.providers.media.util.FileUtils.extractOwnerPackageNameFromRelativePath;
 import static com.android.providers.media.util.FileUtils.extractPathOwnerPackageName;
 import static com.android.providers.media.util.FileUtils.extractRelativePath;
-import static com.android.providers.media.util.FileUtils.extractRelativePathForDirectory;
+import static com.android.providers.media.util.FileUtils.extractRelativePathWithDisplayName;
 import static com.android.providers.media.util.FileUtils.extractTopLevelDir;
 import static com.android.providers.media.util.FileUtils.extractVolumeName;
 import static com.android.providers.media.util.FileUtils.getAbsoluteSanitizedPath;
 import static com.android.providers.media.util.FileUtils.isDataOrObbPath;
+import static com.android.providers.media.util.FileUtils.isDataOrObbRelativePath;
 import static com.android.providers.media.util.FileUtils.isDownload;
+import static com.android.providers.media.util.FileUtils.isObbOrChildRelativePath;
 import static com.android.providers.media.util.FileUtils.sanitizePath;
 import static com.android.providers.media.util.Logging.LOGV;
 import static com.android.providers.media.util.Logging.TAG;
@@ -77,6 +84,9 @@ import android.app.DownloadManager;
 import android.app.PendingIntent;
 import android.app.RecoverableSecurityException;
 import android.app.RemoteAction;
+import android.app.compat.CompatChanges;
+import android.compat.annotation.ChangeId;
+import android.compat.annotation.EnabledAfter;
 import android.content.BroadcastReceiver;
 import android.content.ClipData;
 import android.content.ClipDescription;
@@ -223,6 +233,13 @@ import java.util.regex.Pattern;
  */
 public class MediaProvider extends ContentProvider {
     /**
+     * Enables checks to stop apps from inserting and updating to private files via media provider.
+     */
+    @ChangeId
+    @EnabledAfter(targetSdkVersion = android.os.Build.VERSION_CODES.R)
+    static final long ENABLE_CHECKS_FOR_PRIVATE_FILES = 172100307L;
+
+    /**
      * Regex of a selection string that matches a specific ID.
      */
     static final Pattern PATTERN_SELECTION_ID = Pattern.compile(
@@ -310,6 +327,11 @@ public class MediaProvider extends ContentProvider {
     private static final Map<String, Collection<File>> sCachedVolumeScanPaths = new ArrayMap<>();
     @GuardedBy("sCacheLock")
     private static final ArrayMap<File, String> sCachedVolumePathToId = new ArrayMap<>();
+
+    /**
+     * Please use {@link getDownloadsProviderAuthority()} instead of using this directly.
+     */
+    private static final String DOWNLOADS_PROVIDER_AUTHORITY = "downloads";
 
     @GuardedBy("mShouldRedactThreadIds")
     private final LongArray mShouldRedactThreadIds = new LongArray();
@@ -411,6 +433,8 @@ public class MediaProvider extends ContentProvider {
     private StorageManager mStorageManager;
     private AppOpsManager mAppOpsManager;
     private PackageManager mPackageManager;
+    private int mExternalStorageAuthorityAppId;
+    private int mDownloadsAuthorityAppId;
 
     private Size mThumbSize;
 
@@ -920,6 +944,19 @@ public class MediaProvider extends ContentProvider {
                     null /* all packages */, mModeListener);
         } catch (IllegalArgumentException e) {
             Log.w(TAG, "Failed to start watching " + PermissionUtils.OPSTR_NO_ISOLATED_STORAGE, e);
+        }
+
+        ProviderInfo provider = mPackageManager.resolveContentProvider(
+                getDownloadsProviderAuthority(), PackageManager.MATCH_DIRECT_BOOT_AWARE
+                | PackageManager.MATCH_DIRECT_BOOT_UNAWARE);
+        if (provider != null) {
+            mDownloadsAuthorityAppId = UserHandle.getAppId(provider.applicationInfo.uid);
+        }
+
+        provider = mPackageManager.resolveContentProvider(getExternalStorageProviderAuthority(),
+                PackageManager.MATCH_DIRECT_BOOT_AWARE | PackageManager.MATCH_DIRECT_BOOT_UNAWARE);
+        if (provider != null) {
+            mExternalStorageAuthorityAppId = UserHandle.getAppId(provider.applicationInfo.uid);
         }
         return true;
     }
@@ -1494,7 +1531,7 @@ public class MediaProvider extends ContentProvider {
             }
 
             // Get relative path for the contents of given directory.
-            String relativePath = extractRelativePathForDirectory(path);
+            String relativePath = extractRelativePathWithDisplayName(path);
 
             if (relativePath == null) {
                 // Path is /storage/emulated/, if relativePath is null, MediaProvider doesn't
@@ -1737,8 +1774,8 @@ public class MediaProvider extends ContentProvider {
             throws IllegalArgumentException {
         // Try a simple check to see if the caller has full access to the given collections first
         // before falling back to performing a query to probe for access.
-        final String oldRelativePath = extractRelativePathForDirectory(oldPath);
-        final String newRelativePath = extractRelativePathForDirectory(newPath);
+        final String oldRelativePath = extractRelativePathWithDisplayName(oldPath);
+        final String newRelativePath = extractRelativePathWithDisplayName(newPath);
         boolean hasFullAccessToOldPath = false;
         boolean hasFullAccessToNewPath = false;
         for (String defaultDir : getIncludedDefaultDirectories()) {
@@ -2723,6 +2760,8 @@ public class MediaProvider extends ContentProvider {
             assertFileColumnsSane(match, uri, values);
         }
 
+        assertPrivatePathNotInValues(values);
+
         // Drop columns that aren't relevant for special tables
         switch (match) {
             case AUDIO_ALBUMART:
@@ -2739,6 +2778,48 @@ public class MediaProvider extends ContentProvider {
         }
 
         Trace.endSection();
+    }
+
+    /**
+     * For apps targetSdk >= S: Check that values does not contain any external private path.
+     * For all apps: Check that values does not contain any other app's external private paths.
+     */
+    private void assertPrivatePathNotInValues(ContentValues values)
+            throws IllegalArgumentException {
+        ArrayList<String> relativePaths = new ArrayList<String>();
+        relativePaths.add(extractRelativePath(values.getAsString(MediaColumns.DATA)));
+        relativePaths.add(values.getAsString(MediaColumns.RELATIVE_PATH));
+
+        for (final String relativePath : relativePaths) {
+            if (!isDataOrObbRelativePath(relativePath)) {
+                continue;
+            }
+
+            /**
+             * Don't allow apps to insert/update database row to files in Android/data or
+             * Android/obb dirs. These are app private directories and files in these private
+             * directories can't be added to public media collection.
+             *
+             * Note: For backwards compatibility we allow apps with targetSdk < S to insert private
+             * files to MediaProvider
+             */
+            if (CompatChanges.isChangeEnabled(ENABLE_CHECKS_FOR_PRIVATE_FILES,
+                    Binder.getCallingUid())) {
+                throw new IllegalArgumentException(
+                        "Inserting private file: " + relativePath + " is not allowed.");
+            }
+
+            /**
+             * Restrict all (legacy and non-legacy) apps from inserting paths in other
+             * app's private directories.
+             * Allow legacy apps to insert/update files in app private directories for backward
+             * compatibility but don't allow them to do so in other app's private directories.
+             */
+            if (!isCallingIdentityAllowedAccessToDataOrObbPath(relativePath)) {
+                throw new IllegalArgumentException(
+                        "Inserting private file: " + relativePath + " is not allowed.");
+            }
+        }
     }
 
     /**
@@ -5327,6 +5408,8 @@ public class MediaProvider extends ContentProvider {
             Trace.endSection();
         }
 
+        assertPrivatePathNotInValues(initialValues);
+
         // Make sure any updated paths look sane
         assertFileColumnsSane(match, uri, initialValues);
 
@@ -7038,6 +7121,87 @@ public class MediaProvider extends ContentProvider {
         }
     }
 
+    private boolean isCallingIdentityAllowedAccessToDataOrObbPath(String relativePath) {
+        // Files under the apps own private directory
+        final String appSpecificDir = extractOwnerPackageNameFromRelativePath(relativePath);
+
+        if (appSpecificDir != null && isCallingIdentitySharedPackageName(appSpecificDir)) {
+            return true;
+        }
+        // This is a private-package relativePath; return true if accessible by the caller
+        return isCallingIdentityAllowedSpecialPrivatePathAccess(relativePath);
+    }
+
+    /**
+     * @return true iff the caller has installer privileges which gives write access to obb dirs.
+     */
+    private boolean isCallingIdentityAllowedInstallerAccess() {
+        final boolean hasWrite = mCallingIdentity.get().
+                hasPermission(PERMISSION_WRITE_EXTERNAL_STORAGE);
+
+        if (!hasWrite) {
+            return false;
+        }
+
+        // We're only willing to give out installer access if they also hold
+        // runtime permission; this is a firm CDD requirement
+        final boolean hasInstall = mCallingIdentity.get().
+                hasPermission(PERMISSION_INSTALL_PACKAGES);
+
+        if (hasInstall) {
+            return true;
+        }
+
+        // OPSTR_REQUEST_INSTALL_PACKAGES is granted/denied per package but vold can't
+        // update mountpoints of a specific package. So, check the appop for all packages
+        // sharing the uid and allow same level of storage access for all packages even if
+        // one of the packages has the appop granted.
+        // To maintain consistency of access in primary volume and secondary volumes use the same
+        // logic as we do for Zygote.MOUNT_EXTERNAL_INSTALLER view.
+        return mCallingIdentity.get().hasPermission(APPOP_REQUEST_INSTALL_PACKAGES_FOR_SHARED_UID);
+    }
+
+    private String getExternalStorageProviderAuthority() {
+        return MediaStore.EXTERNAL_STORAGE_PROVIDER_AUTHORITY;
+    }
+
+    private String getDownloadsProviderAuthority() {
+        return DOWNLOADS_PROVIDER_AUTHORITY;
+    }
+
+    private boolean isCallingIdentityDownloadProvider() {
+        return getCallingUidOrSelf() == mDownloadsAuthorityAppId;
+    }
+
+    private boolean isCallingIdentityExternalStorageProvider() {
+        return getCallingUidOrSelf() == mExternalStorageAuthorityAppId;
+    }
+
+    private boolean isCallingIdentityMtp() {
+        return mCallingIdentity.get().hasPermission(PERMISSION_ACCESS_MTP);
+    }
+
+    /**
+     * The following apps have access to all private-app directories on secondary volumes:
+     *    * ExternalStorageProvider
+     *    * DownloadProvider
+     *    * Signature apps with ACCESS_MTP permission granted
+     *      (Note: For Android R we also allow privileged apps with ACCESS_MTP to access all
+     *      private-app directories, this additional access is removed for Android S+).
+     *
+     * Installer apps can only access private-app directories on Android/obb.
+     *
+     * @param relativePath the relative path of the file to access
+     */
+    private boolean isCallingIdentityAllowedSpecialPrivatePathAccess(String relativePath) {
+        if (isCallingIdentityDownloadProvider() ||
+                isCallingIdentityExternalStorageProvider() || isCallingIdentityMtp()) {
+            return true;
+        }
+        return (isObbOrChildRelativePath(relativePath) &&
+                isCallingIdentityAllowedInstallerAccess());
+    }
+
     private boolean checkCallingPermissionGlobal(Uri uri, boolean forWrite) {
         // System internals can work with all media
         if (isCallingPackageSelf() || isCallingPackageShell()) {
@@ -7775,6 +7939,10 @@ public class MediaProvider extends ContentProvider {
 
     private boolean isCallingPackageSystemGallery() {
         return mCallingIdentity.get().hasPermission(PERMISSION_IS_SYSTEM_GALLERY);
+    }
+
+    private int getCallingUidOrSelf() {
+        return mCallingIdentity.get().uid;
     }
 
     @Deprecated

--- a/src/com/android/providers/media/util/FileUtils.java
+++ b/src/com/android/providers/media/util/FileUtils.java
@@ -889,8 +889,29 @@ public class FileUtils {
     /**
      * Regex that matches Android/obb or Android/data path.
      */
-    public static final Pattern PATTERN_DATA_OR_OBB_PATH = Pattern.compile(
-            "(?i)^/storage/[^/]+/(?:[0-9]+/)?Android/(?:data|obb)/?$");
+    private static final Pattern PATTERN_DATA_OR_OBB_PATH = Pattern.compile(
+            "(?i)^/storage/[^/]+/(?:[0-9]+/)?Android/(?:data|obb)(?:/.*)?$");
+
+     /**
+     * Regex that matches paths in all well-known package-specific relative directory
+     * path (as defined in {@link MediaColumns#RELATIVE_PATH})
+     * and which captures the package name as the first group.
+     */
+    private static final Pattern PATTERN_OWNED_RELATIVE_PATH = Pattern.compile(
+            "(?i)^Android/(?:data|media|obb|sandbox)/([^/]+)(/?.*)?");
+
+    /**
+     * Regex that matches Android/obb or Android/data relative path (as defined in
+     * {@link MediaColumns#RELATIVE_PATH})
+     */
+    private static final Pattern PATTERN_DATA_OR_OBB_RELATIVE_PATH = Pattern.compile(
+            "(?i)^Android/(?:data|obb)(?:/.*)?$");
+
+    /**
+     * Regex that matches Android/obb {@link MediaColumns#RELATIVE_PATH}.
+     */
+    private static final Pattern PATTERN_OBB_OR_CHILD_RELATIVE_PATH = Pattern.compile(
+            "(?i)^Android/obb(?:/.*)?$");
 
     @VisibleForTesting
     public static final String[] DEFAULT_FOLDER_NAMES = {
@@ -970,14 +991,13 @@ public class FileUtils {
     }
 
     /**
-     * Returns relative path for the directory.
+     * Returns relative path with display name.
      */
     @VisibleForTesting
-    public static @Nullable String extractRelativePathForDirectory(@Nullable String directoryPath) {
-        if (directoryPath == null) return null;
+    public static @Nullable String extractRelativePathWithDisplayName(@Nullable String path) {
+        if (path == null) return null;
 
-        if (directoryPath.equals("/storage/emulated") ||
-                directoryPath.equals("/storage/emulated/")) {
+        if (path.equals("/storage/emulated") || path.equals("/storage/emulated/")) {
             // This path is not reachable for MediaProvider.
             return null;
         }
@@ -986,18 +1006,18 @@ public class FileUtils {
         // same PATTERN_RELATIVE_PATH to match relative path for directory. For example, relative
         // path of '/storage/<volume_name>' is null where as relative path for directory is "/", for
         // PATTERN_RELATIVE_PATH to match '/storage/<volume_name>', it should end with "/".
-        if (!directoryPath.endsWith("/")) {
+        if (!path.endsWith("/")) {
             // Relative path for directory should end with "/".
-            directoryPath += "/";
+            path += "/";
         }
 
-        final Matcher matcher = PATTERN_RELATIVE_PATH.matcher(directoryPath);
+        final Matcher matcher = PATTERN_RELATIVE_PATH.matcher(path);
         if (matcher.find()) {
-            if (matcher.end() == directoryPath.length()) {
+            if (matcher.end() == path.length()) {
                 // This is the top-level directory, so relative path is "/"
                 return "/";
             }
-            return directoryPath.substring(matcher.end());
+            return path.substring(matcher.end());
         }
         return null;
     }
@@ -1007,17 +1027,43 @@ public class FileUtils {
         final Matcher m = PATTERN_OWNED_PATH.matcher(path);
         if (m.matches()) {
             return m.group(1);
-        } else {
-            return null;
         }
+        return null;
+    }
+
+    public static @Nullable String extractOwnerPackageNameFromRelativePath(@Nullable String path) {
+        if (path == null) return null;
+        final Matcher m = PATTERN_OWNED_RELATIVE_PATH.matcher(path);
+        if (m.matches()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+    /**
+     * Returns true if path is Android/data or Android/obb path.
+     */
+    public static boolean isDataOrObbPath(@Nullable String path) {
+        if (path == null) return false;
+        final Matcher m = PATTERN_DATA_OR_OBB_PATH.matcher(path);
+        return m.matches();
     }
 
     /**
      * Returns true if relative path is Android/data or Android/obb path.
      */
-    public static boolean isDataOrObbPath(String path) {
+    public static boolean isDataOrObbRelativePath(@Nullable String path) {
         if (path == null) return false;
-        final Matcher m = PATTERN_DATA_OR_OBB_PATH.matcher(path);
+        final Matcher m = PATTERN_DATA_OR_OBB_RELATIVE_PATH.matcher(path);
+        return m.matches();
+    }
+
+    /**
+     * Returns true if relative path is Android/obb path.
+     */
+    public static boolean isObbOrChildRelativePath(@Nullable String path) {
+        if (path == null) return false;
+        final Matcher m = PATTERN_OBB_OR_CHILD_RELATIVE_PATH.matcher(path);
         return m.matches();
     }
 
@@ -1259,7 +1305,7 @@ public class FileUtils {
 
         // DCIM/Camera should always be visible regardless of .nomedia presence.
         if (CAMERA_RELATIVE_PATH.equalsIgnoreCase(
-                extractRelativePathForDirectory(dir.getAbsolutePath()))) {
+                extractRelativePathWithDisplayName(dir.getAbsolutePath()))) {
             nomedia.delete();
             return false;
         }

--- a/src/com/android/providers/media/util/PermissionUtils.java
+++ b/src/com/android/providers/media/util/PermissionUtils.java
@@ -16,7 +16,9 @@
 
 package com.android.providers.media.util;
 
+import static android.Manifest.permission.ACCESS_MTP;
 import static android.Manifest.permission.BACKUP;
+import static android.Manifest.permission.INSTALL_PACKAGES;
 import static android.Manifest.permission.MANAGE_EXTERNAL_STORAGE;
 import static android.Manifest.permission.READ_EXTERNAL_STORAGE;
 import static android.Manifest.permission.UPDATE_DEVICE_STATS;
@@ -26,6 +28,7 @@ import static android.app.AppOpsManager.OPSTR_LEGACY_STORAGE;
 import static android.app.AppOpsManager.OPSTR_READ_MEDIA_AUDIO;
 import static android.app.AppOpsManager.OPSTR_READ_MEDIA_IMAGES;
 import static android.app.AppOpsManager.OPSTR_READ_MEDIA_VIDEO;
+import static android.app.AppOpsManager.OPSTR_REQUEST_INSTALL_PACKAGES;
 import static android.app.AppOpsManager.OPSTR_WRITE_MEDIA_AUDIO;
 import static android.app.AppOpsManager.OPSTR_WRITE_MEDIA_IMAGES;
 import static android.app.AppOpsManager.OPSTR_WRITE_MEDIA_VIDEO;
@@ -197,6 +200,32 @@ public class PermissionUtils {
                 || checkAppOp(
                         context, OPSTR_WRITE_MEDIA_VIDEO, uid, packageName, attributionTag,
                 generateAppOpMessage(packageName, sOpDescription.get()));
+    }
+
+    /**
+     * Returns {@code true} if any package for the given uid has request_install_packages app op.
+     */
+    public static boolean checkAppOpRequestInstallPackagesForSharedUid(@NonNull Context context,
+            int uid, @NonNull String[] sharedPackageNames, @Nullable String attributionTag) {
+        for (String packageName : sharedPackageNames) {
+            if (checkAppOp(context, OPSTR_REQUEST_INSTALL_PACKAGES, uid, packageName,
+                    attributionTag, generateAppOpMessage(packageName, sOpDescription.get()))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean checkPermissionInstallPackages(@NonNull Context context, int pid, int uid,
+            @NonNull String packageName, @Nullable String attributionTag) {
+        return checkPermissionForDataDelivery(context, INSTALL_PACKAGES, pid,
+                uid, packageName, attributionTag, null);
+    }
+
+    public static boolean checkPermissionAccessMtp(@NonNull Context context, int pid, int uid,
+            @NonNull String packageName, @Nullable String attributionTag) {
+        return checkPermissionForDataDelivery(context, ACCESS_MTP, pid,
+                uid, packageName, attributionTag, null);
     }
 
     @VisibleForTesting

--- a/tests/src/com/android/providers/media/MediaProviderTest.java
+++ b/tests/src/com/android/providers/media/MediaProviderTest.java
@@ -17,7 +17,7 @@
 package com.android.providers.media;
 
 import static com.android.providers.media.scan.MediaScannerTest.stage;
-import static com.android.providers.media.util.FileUtils.extractRelativePathForDirectory;
+import static com.android.providers.media.util.FileUtils.extractRelativePathWithDisplayName;
 import static com.android.providers.media.util.FileUtils.isDownload;
 import static com.android.providers.media.util.FileUtils.isDownloadDir;
 
@@ -977,7 +977,7 @@ public class MediaProviderTest {
                 "Foo.jpg",
                 "storage/Foo"
         }) {
-            assertEquals(null, FileUtils.extractRelativePathForDirectory(path));
+            assertEquals(null, FileUtils.extractRelativePathWithDisplayName(path));
         }
     }
 
@@ -1117,7 +1117,7 @@ public class MediaProviderTest {
 
     private static void assertRelativePathForDirectory(String directoryPath, String relativePath) {
         assertWithMessage("extractRelativePathForDirectory(" + directoryPath + ") :")
-                .that(extractRelativePathForDirectory(directoryPath))
+                .that(extractRelativePathWithDisplayName(directoryPath))
                 .isEqualTo(relativePath);
     }
 

--- a/tests/src/com/android/providers/media/util/FileUtilsTest.java
+++ b/tests/src/com/android/providers/media/util/FileUtilsTest.java
@@ -40,15 +40,22 @@ import static com.android.providers.media.util.FileUtils.buildUniqueFile;
 import static com.android.providers.media.util.FileUtils.extractDisplayName;
 import static com.android.providers.media.util.FileUtils.extractFileExtension;
 import static com.android.providers.media.util.FileUtils.extractFileName;
+import static com.android.providers.media.util.FileUtils.extractOwnerPackageNameFromRelativePath;
+import static com.android.providers.media.util.FileUtils.extractPathOwnerPackageName;
 import static com.android.providers.media.util.FileUtils.extractRelativePath;
 import static com.android.providers.media.util.FileUtils.extractTopLevelDir;
 import static com.android.providers.media.util.FileUtils.extractVolumeName;
 import static com.android.providers.media.util.FileUtils.extractVolumePath;
+import static com.android.providers.media.util.FileUtils.isDataOrObbPath;
+import static com.android.providers.media.util.FileUtils.isDataOrObbRelativePath;
+import static com.android.providers.media.util.FileUtils.isObbOrChildRelativePath;
 import static com.android.providers.media.util.FileUtils.translateModeAccessToPosix;
 import static com.android.providers.media.util.FileUtils.translateModePfdToPosix;
 import static com.android.providers.media.util.FileUtils.translateModePosixToPfd;
 import static com.android.providers.media.util.FileUtils.translateModePosixToString;
 import static com.android.providers.media.util.FileUtils.translateModeStringToPosix;
+
+import static com.google.common.truth.Truth.assertThat;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -641,6 +648,95 @@ public class FileUtilsTest {
         FileUtils.computeDateExpires(values);
         assertTrue(values.containsKey(MediaColumns.DATE_EXPIRES));
         assertNull(values.get(MediaColumns.DATE_EXPIRES));
+    }
+
+    @Test
+    public void testExtractPathOwnerPackageName() {
+        assertThat(extractPathOwnerPackageName("/storage/emulated/0/Android/data/foo"))
+                .isEqualTo("foo");
+        assertThat(extractPathOwnerPackageName("/storage/emulated/0/Android/obb/foo"))
+                .isEqualTo("foo");
+        assertThat(extractPathOwnerPackageName("/storage/emulated/0/Android/media/foo"))
+                .isEqualTo("foo");
+        assertThat(extractPathOwnerPackageName("/storage/ABCD-1234/Android/data/foo"))
+                .isEqualTo("foo");
+        assertThat(extractPathOwnerPackageName("/storage/ABCD-1234/Android/obb/foo"))
+                .isEqualTo("foo");
+        assertThat(extractPathOwnerPackageName("/storage/ABCD-1234/Android/media/foo"))
+                .isEqualTo("foo");
+
+        assertThat(extractPathOwnerPackageName("/storage/emulated/0/Android/data")).isNull();
+        assertThat(extractPathOwnerPackageName("/storage/emulated/0/Android/obb")).isNull();
+        assertThat(extractPathOwnerPackageName("/storage/emulated/0/Android/media")).isNull();
+        assertThat(extractPathOwnerPackageName("/storage/ABCD-1234/Android/media")).isNull();
+        assertThat(extractPathOwnerPackageName("/storage/emulated/0/Pictures/foo")).isNull();
+        assertThat(extractPathOwnerPackageName("Android/data")).isNull();
+        assertThat(extractPathOwnerPackageName("Android/obb")).isNull();
+    }
+
+    @Test
+    public void testExtractOwnerPackageNameFromRelativePath() {
+        assertThat(extractOwnerPackageNameFromRelativePath("Android/data/foo")).isEqualTo("foo");
+        assertThat(extractOwnerPackageNameFromRelativePath("Android/obb/foo")).isEqualTo("foo");
+        assertThat(extractOwnerPackageNameFromRelativePath("Android/media/foo")).isEqualTo("foo");
+        assertThat(extractOwnerPackageNameFromRelativePath("Android/media/foo.com/files"))
+                .isEqualTo("foo.com");
+
+        assertThat(extractOwnerPackageNameFromRelativePath("/storage/emulated/0/Android/data/foo"))
+                .isNull();
+        assertThat(extractOwnerPackageNameFromRelativePath("Android/data")).isNull();
+        assertThat(extractOwnerPackageNameFromRelativePath("Android/obb")).isNull();
+        assertThat(extractOwnerPackageNameFromRelativePath("Android/media")).isNull();
+        assertThat(extractOwnerPackageNameFromRelativePath("Pictures/foo")).isNull();
+    }
+
+    @Test
+    public void testIsDataOrObbPath() {
+        assertThat(isDataOrObbPath("/storage/emulated/0/Android/data")).isTrue();
+        assertThat(isDataOrObbPath("/storage/emulated/0/Android/obb")).isTrue();
+        assertThat(isDataOrObbPath("/storage/ABCD-1234/Android/data")).isTrue();
+        assertThat(isDataOrObbPath("/storage/ABCD-1234/Android/obb")).isTrue();
+        assertThat(isDataOrObbPath("/storage/emulated/0/Android/data/foo")).isTrue();
+        assertThat(isDataOrObbPath("/storage/emulated/0/Android/obb/foo")).isTrue();
+        assertThat(isDataOrObbPath("/storage/ABCD-1234/Android/data/foo")).isTrue();
+        assertThat(isDataOrObbPath("/storage/ABCD-1234/Android/obb/foo")).isTrue();
+
+        assertThat(isDataOrObbPath("/storage/emulated/0/Android/")).isFalse();
+        assertThat(isDataOrObbPath("/storage/emulated/0/Android/media/")).isFalse();
+        assertThat(isDataOrObbPath("/storage/ABCD-1234/Android/media/")).isFalse();
+        assertThat(isDataOrObbPath("/storage/emulated/0/Pictures/")).isFalse();
+        assertThat(isDataOrObbPath("/storage/ABCD-1234/Android/obbfoo")).isFalse();
+        assertThat(isDataOrObbPath("/storage/emulated/0/Android/datafoo")).isFalse();
+        assertThat(isDataOrObbPath("Android/")).isFalse();
+        assertThat(isDataOrObbPath("Android/media/")).isFalse();
+    }
+
+    @Test
+    public void testIsDataOrObbRelativePath() {
+        assertThat(isDataOrObbRelativePath("Android/data")).isTrue();
+        assertThat(isDataOrObbRelativePath("Android/obb")).isTrue();
+        assertThat(isDataOrObbRelativePath("Android/data/foo")).isTrue();
+        assertThat(isDataOrObbRelativePath("Android/obb/foo")).isTrue();
+
+        assertThat(isDataOrObbRelativePath("/storage/emulated/0/Android/data")).isFalse();
+        assertThat(isDataOrObbRelativePath("Android/")).isFalse();
+        assertThat(isDataOrObbRelativePath("Android/media/")).isFalse();
+        assertThat(isDataOrObbRelativePath("Pictures/")).isFalse();
+    }
+
+    @Test
+    public void testIsObbOrChildRelativePath() {
+        assertThat(isObbOrChildRelativePath("Android/obb")).isTrue();
+        assertThat(isObbOrChildRelativePath("Android/obb/")).isTrue();
+        assertThat(isObbOrChildRelativePath("Android/obb/foo.com")).isTrue();
+
+        assertThat(isObbOrChildRelativePath("/storage/emulated/0/Android/obb")).isFalse();
+        assertThat(isObbOrChildRelativePath("/storage/emulated/0/Android/")).isFalse();
+        assertThat(isObbOrChildRelativePath("Android/")).isFalse();
+        assertThat(isObbOrChildRelativePath("Android/media/")).isFalse();
+        assertThat(isObbOrChildRelativePath("Pictures/")).isFalse();
+        assertThat(isObbOrChildRelativePath("Android/obbfoo")).isFalse();
+        assertThat(isObbOrChildRelativePath("Android/data")).isFalse();
     }
 
     private static File touch(File dir, String name) throws IOException {


### PR DESCRIPTION
We allow legacy apps to insert/update content values such that they can
add private files to MediaStore database. Restrict such apps to
insert/update content in other app's private directories. Add extensive
logic to allow apps with special access (installers, access_mtp,
downloadsprovider) to have same level of access to other app's private
directories.

Retrict System Gallery apps and apps with MANAGE_EXTERNAL_STORAGE
permission to insert private path files.

Bug: 201667614
Test: atest FileUtilsTest
Test: atest CtsScopedStorageHostTest
Test: atest LegacyStorageTest:LegacyStorageHostTest
Change-Id: I52481b24b137790d49845f1a4b00978c63ed183b
Merged-In: I52481b24b137790d49845f1a4b00978c63ed183b
(cherry picked from commit 220971d4e9dddb91d8073c0c295fe0fff057249d)
Merged-In:I52481b24b137790d49845f1a4b00978c63ed183b
Signed-off-by: Anushek Prasal <anushekprasal@gmail.com>